### PR TITLE
Fix compile error: googletest

### DIFF
--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -1,6 +1,6 @@
 package=googletest
 $(package)_version=1.8.0
-$(package)_download_path=https://github.com/google/$(package)/archive/
+$(package)_download_path=https://github.com/google/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_download_file=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8


### PR DESCRIPTION
I'm not sure if the failure is caused by specific versions of curl, but the url generated by this mk file produces an extra slash, leading to a 404.