### PR TITLE
Fix z_importkey

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -129,7 +129,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_shieldcoinbase", 3},
     { "z_getoperationstatus", 0},
     { "z_getoperationresult", 0},
-    { "z_importkey", 1 },
     { "paxprice", 4 },
     { "paxprices", 3 },
     { "paxpending", 0 },


### PR DESCRIPTION
As proposed in https://github.com/jl777/komodo/pull/1023. Without this
change, an error is given: `error: Error JSON:no` when any value is
given for the second parameter.