### PR TITLE
bump 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,27 +44,25 @@ Same Zcash is based on Bitcoin's code, with difference Zcash intends to offer a 
 
 ### Dependencies
 
-    1. Ubuntu
-	
+**1. Ubuntu**
 ```shell
-	#The following packages are needed:
-	sudo apt-get install \
-		build-essential pkg-config libc6-dev m4 \
-		g++-multilib autoconf libtool ncurses-dev \
-		unzip git python python-zmq zlib1g-dev wget \
-		libcurl4-gnutls-dev bsdmainutils automake curl bc dc jq
+#The following packages are needed:
+sudo apt-get install \
+	build-essential pkg-config libc6-dev m4 \
+	g++-multilib autoconf libtool ncurses-dev \
+	unzip git python python-zmq zlib1g-dev wget \
+	libcurl4-gnutls-dev bsdmainutils automake curl bc dc jq
 ```
 
-    2. Windows
-	
+**2. Windows**
 ```shell
-    sudo apt-get install \
-        build-essential pkg-config libc6-dev m4 g++-multilib \
-        autoconf libtool ncurses-dev unzip git python \
-        zlib1g-dev wget bsdmainutils automake mingw-w64
-		
-		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
-		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
+sudo apt-get install \
+	build-essential pkg-config libc6-dev m4 g++-multilib \
+	autoconf libtool ncurses-dev unzip git python \
+	zlib1g-dev wget bsdmainutils automake mingw-w64
+
+	sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
+	sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
 ```
 
 Secure Setup

--- a/README.md
+++ b/README.md
@@ -45,17 +45,19 @@ Same Zcash is based on Bitcoin's code, with difference Zcash intends to offer a 
 ### Dependencies
 
     1. Ubuntu
-	```{r, engine='bash'}
+	
+```shell
 	#The following packages are needed:
 	sudo apt-get install \
 		build-essential pkg-config libc6-dev m4 \
 		g++-multilib autoconf libtool ncurses-dev \
 		unzip git python python-zmq zlib1g-dev wget \
 		libcurl4-gnutls-dev bsdmainutils automake curl bc dc jq
-	```
+```
 
     2. Windows
-    ```{r, engine='bash'}
+	
+```shell
     sudo apt-get install \
         build-essential pkg-config libc6-dev m4 g++-multilib \
         autoconf libtool ncurses-dev unzip git python \
@@ -63,7 +65,7 @@ Same Zcash is based on Bitcoin's code, with difference Zcash intends to offer a 
 		
 		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
 		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
-    ```
+```
 
 Secure Setup
 -----------------

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is the official Safecoin sourcecode repository based on https://github.com/
 - Mining Algorithm: Equihash 192_7
 
 ## About this Project
-Safecoin is a fork of the Komodo and Zcash projects, although we have incorporated significant changes including TLS Encryption from Horizen and Equihash 144_5, in collaboration with BTCZ.  Safecoin was launched as a pure Proof of Work coin, and has never had any ICO or Sale of any kind.   We are an Open Source, Peer to Peer project and we support and contribute to likewise initiatives.
+Safecoin is a fork of the Komodo and Zcash projects, although we have incorporated significant changes including TLS 1.3 Encryption from Horizen and Equihash 144_5, in collaboration with BTCZ.  Safecoin was launched as a pure Proof of Work coin, and has never had any ICO or Sale of any kind.   We are an Open Source, Peer to Peer project and we support and contribute to likewise initiatives.
 Same Zcash is based on Bitcoin's code, with difference Zcash intends to offer a far higher standard of privacy through a sophisticated zero-knowledge proving scheme that preserves confidentiality of transaction metadata. Technical details are available in our [Protocol Specification](https://github.com/zcash/zips/raw/master/protocol/protocol.pdf).
 
 ## Getting started
@@ -109,6 +109,7 @@ cd safecoin
 #This can take some time.
 ```
 The "disable-mining" binaries are compiled with **--disable-mining** in an attempt to reduce Antivirus false positives, use them if you're packaging GUI wallets.
+
 **safecoin is experimental and a work-in-progress.** Use at your own risk.
 
 To reset the Safecoin blockchain change into the *~/.safecoin* data directory and delete the corresponding files by running `rm -rf blocks chainstate debug.log safecoinstate db.log`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Safecoin Logo](https://raw.githubusercontent.com/Fair-Exchange/safecoinwiki/master/Logos/SafeCoin/SafeCoin-Logo-with-text.png "Safecoin Logo")
 
 
-## Safecoin v2.0.0
+## Safecoin v2.0.2
 ==============
 
 This is the official Safecoin sourcecode repository based on https://github.com/fair-exchange/safecoin. 
@@ -34,7 +34,7 @@ This is the official Safecoin sourcecode repository based on https://github.com/
 - Max Supply: 36.2 million SAFE.
 - Block Time: 1M 2s
 - Block Reward: See schedule
-- Mining Algorithm: Equihash 144_5 (Zhash)
+- Mining Algorithm: Equihash 192_7
 
 ## About this Project
 Safecoin is a fork of the Komodo and Zcash projects, although we have incorporated significant changes including TLS Encryption from Horizen and Equihash 144_5, in collaboration with BTCZ.  Safecoin was launched as a pure Proof of Work coin, and has never had any ICO or Sale of any kind.   We are an Open Source, Peer to Peer project and we support and contribute to likewise initiatives.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,26 @@ Same Zcash is based on Bitcoin's code, with difference Zcash intends to offer a 
 
 ### Dependencies
 
-```shell
-#The following packages are needed:
-sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python python-zmq zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake curl bc dc jq
-```
+    1. Ubuntu
+	```{r, engine='bash'}
+	#The following packages are needed:
+	sudo apt-get install \
+		build-essential pkg-config libc6-dev m4 \
+		g++-multilib autoconf libtool ncurses-dev \
+		unzip git python python-zmq zlib1g-dev wget \
+		libcurl4-gnutls-dev bsdmainutils automake curl bc dc jq
+	```
+
+    2. Windows
+    ```{r, engine='bash'}
+    sudo apt-get install \
+        build-essential pkg-config libc6-dev m4 g++-multilib \
+        autoconf libtool ncurses-dev unzip git python \
+        zlib1g-dev wget bsdmainutils automake mingw-w64
+		
+		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
+		sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
+    ```
 
 Secure Setup
 -----------------
@@ -89,9 +105,10 @@ git clone https://github.com/fair-exchange/safecoin --branch master --single-bra
 cd safecoin
 ./zcutil/fetch-params.sh
 # -j8 = using 8 threads for the compilation - replace 8 with number of threads you want to use
-./zcutil/build-win.sh -j8
+./zcutil/build-win.sh -j8 --disable-mining
 #This can take some time.
 ```
+The "disable-mining" binaries are compiled with **--disable-mining** in an attempt to reduce Antivirus false positives, use them if you're packaging GUI wallets.
 **safecoin is experimental and a work-in-progress.** Use at your own risk.
 
 To reset the Safecoin blockchain change into the *~/.safecoin* data directory and delete the corresponding files by running `rm -rf blocks chainstate debug.log safecoinstate db.log`
@@ -110,12 +127,10 @@ rpcuser=yourrpcusername
 rpcpassword=yoursecurerpcpassword
 rpcbind=127.0.0.1
 txindex=1
-addnode=dnsseedua.local.support
 addnode=dnsseed.ipv6admin.com
 addnode=dnsseed.fair.exchange
 addnode=explorer.safecoin.org
 addnode=45.63.13.60
-addnode=185.20.184.51
 addnode=176.107.179.32
 addnode=node.safc.cc
 ```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ sudo apt-get install \
 	autoconf libtool ncurses-dev unzip git python \
 	zlib1g-dev wget bsdmainutils automake mingw-w64
 
-	sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
-	sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
+sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
+sudo update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
 ```
 
 Secure Setup

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
 AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 0)
-define(_CLIENT_VERSION_REVISION, 0)
+define(_CLIENT_VERSION_REVISION, 2)
 define(_CLIENT_VERSION_BUILD, 50)
 define(_ZC_BUILD_VAL, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, m4_incr(_CLIENT_VERSION_BUILD), m4_eval(_CLIENT_VERSION_BUILD < 50), 1, m4_eval(_CLIENT_VERSION_BUILD - 24), m4_eval(_CLIENT_VERSION_BUILD == 50), 1, , m4_eval(_CLIENT_VERSION_BUILD - 50)))
 define(_CLIENT_VERSION_SUFFIX, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, _CLIENT_VERSION_REVISION-beta$1, m4_eval(_CLIENT_VERSION_BUILD < 50), 1, _CLIENT_VERSION_REVISION-rc$1, m4_eval(_CLIENT_VERSION_BUILD == 50), 1, _CLIENT_VERSION_REVISION, _CLIENT_VERSION_REVISION-$1)))
@@ -587,13 +587,21 @@ fi
 
 dnl Check Qpid Proton headers and library exist
 if test x$use_proton = xyes; then
-  AC_CHECK_HEADERS([proton/connection.hpp],
+ AC_CHECK_HEADERS([proton/connection.hpp],
     [],
     [AC_MSG_WARN([Proton headers not found, disabling Proton support])
     use_proton=no])
- AC_CHECK_LIB([qpid-proton-cpp], [main],
-    [PROTON_LIBS="-lqpid-proton-cpp -lqpid-proton"],
-    [AC_MSG_WARN([Proton libraries not found, disabling Proton support])
+ AC_CHECK_LIB([qpid-proton-cpp-static], [main],
+    [PROTON_LIBS="-lqpid-proton-cpp-static"],
+    [AC_MSG_WARN([Proton qpid-proton-cpp-static library not found, disabling Proton support])
+    use_proton=no])
+ AC_CHECK_LIB([qpid-proton-core-static], [main],
+    [PROTON_LIBS+=" -lqpid-proton-core-static"],
+    [AC_MSG_WARN([Proton qpid-proton-core-static library not found, disabling Proton support])
+    use_proton=no])
+ AC_CHECK_LIB([qpid-proton-static], [main],
+    [PROTON_LIBS+=" -lqpid-proton-static"],
+    [AC_MSG_WARN([Proton qpid-proton-static library not found, disabling Proton support])
     use_proton=no])
 fi
 if test x$use_proton = xyes; then

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,9 +1,8 @@
-
 package=boost
-$(package)_version=1_66_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.66.0/source
+$(package)_version=1_70_0
+$(package)_download_path=https://dl.bintray.com/boostorg/release/1.70.0/source
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9
+$(package)_sha256_hash=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.1.0j
+$(package)_version=1.1.1c
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246
+$(package)_sha256_hash=f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -92,7 +92,7 @@ $(package)_config_opts_i686_mingw32=mingw
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
+  sed -i.old 's/built on: $$$$date/built on: date not available/' util/mkbuildinf.pl && \
   sed -i.old "s|\"engines\", \"apps\", \"test\"|\"engines\"|" Configure
 endef
 

--- a/depends/packages/proton.mk
+++ b/depends/packages/proton.mk
@@ -1,8 +1,8 @@
 package=proton
-$(package)_version=0.17.0
+$(package)_version=0.26.0
 $(package)_download_path=https://archive.apache.org/dist/qpid/proton/$($(package)_version)
 $(package)_file_name=qpid-proton-$($(package)_version).tar.gz
-$(package)_sha256_hash=6ffd26d3d0e495bfdb5d9fefc5349954e6105ea18cc4bb191161d27742c5a01a
+$(package)_sha256_hash=0eddac870f0085b9aeb0c9da333bd3f53fedb7c872164171a7cc06761ddbbd75
 $(package)_patches=minimal-build.patch
 
 define $(package)_preprocess_cmds
@@ -11,7 +11,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  cd build; cmake .. -DCMAKE_CXX_STANDARD=11 -DCMAKE_INSTALL_PREFIX=/ -DSYSINSTALL_BINDINGS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_PYTHON=OFF -DBUILD_PHP=OFF -DBUILD_JAVA=OFF -DBUILD_PERL=OFF -DBUILD_RUBY=OFF -DBUILD_JAVASCRIPT=OFF -DBUILD_GO=OFF
+  cd build; cmake .. -DCMAKE_CXX_STANDARD=11 -DCMAKE_INSTALL_PREFIX=/ -DSYSINSTALL_BINDINGS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_PYTHON=OFF -DBUILD_RUBY=OFF -DBUILD_GO=OFF -DBUILD_STATIC_LIBS=ON -DLIB_SUFFIX= -DENABLE_JSONCPP=
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,13 +1,12 @@
 package=rust
-$(package)_version=1.28.0
+$(package)_version=1.32.0
 $(package)_download_path=https://static.rust-lang.org/dist
-
 $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash_linux=2a1390340db1d24a9498036884e6b2748e9b4b057fc5219694e298bdaa37b810
+$(package)_sha256_hash_linux=e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-$(package)_sha256_hash_darwin=5d7a70ed4701fe9410041c1eea025c95cad97e5b3d8acc46426f9ac4f9f02393
+$(package)_sha256_hash_darwin=f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304
 $(package)_file_name_mingw32=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
-$(package)_sha256_hash_mingw32=55c07426f791c51c8a2b6934b35784175c4abb4e03f123f3e847109c4dc1ad8b
+$(package)_sha256_hash_mingw32=358e1435347c67dbf33aa9cad6fe501a833d6633ed5d5aa1863d5dffa0349be9
 
 ifeq ($(build_os),darwin)
 $(package)_file_name=$($(package)_file_name_darwin)

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,9 +1,9 @@
 ifeq ($(host_os),mingw32)
 $(package)_version=4.3.1
-$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)
+$(package)_download_path=https://github.com/OleksandrBlack/libzmq/archive
 $(package)_download_file=v$($(package)_version).tar.gz
 $(package)_file_name=libzmq-$($(package)_version).tar.gz
-$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_sha256_hash=cb8ebe5b60dadeb526745610d6237f05a98aba287114d8991dad1fa14f4be354
 
 define $(package)_set_vars
   $(package)_build_env+=

--- a/depends/patches/proton/minimal-build.patch
+++ b/depends/patches/proton/minimal-build.patch
@@ -1,288 +1,299 @@
-From 03f5fc0826115edbfca468261b70c0daf627f488 Mon Sep 17 00:00:00 2001
-From: Simon <simon@bitcartel.com>
-Date: Thu, 27 Apr 2017 17:15:59 -0700
-Subject: [PATCH] Enable C++11, build static library and cpp bindings with minimal dependencies.
-
----
- CMakeLists.txt                            | 13 +++++++------
- examples/cpp/CMakeLists.txt               |  1 +
- proton-c/CMakeLists.txt                   | 32 +++++++++++++++----------------
- proton-c/bindings/CMakeLists.txt          |  6 +++---
- proton-c/bindings/cpp/CMakeLists.txt      | 24 +++++++++++------------
- proton-c/bindings/cpp/docs/CMakeLists.txt |  2 +-
- proton-c/docs/api/CMakeLists.txt          |  2 +-
- 7 files changed, 41 insertions(+), 39 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b538ffd..4a5e787 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -18,14 +18,15 @@
- #
- cmake_minimum_required (VERSION 2.8.7)
+diff -ur qpid-proton-0.26.0/c/CMakeLists.txt qpid-proton-patched/c/CMakeLists.txt
+--- qpid-proton-0.26.0/c/CMakeLists.txt	2018-10-04 04:09:02.000000000 -0600
++++ qpid-proton-patched/c/CMakeLists.txt	2019-03-25 17:32:41.521213312 -0600
+@@ -443,15 +443,15 @@
+   ${qpid-proton-include-generated}
+ )
  
-+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
- project (Proton C)
+-add_library (qpid-proton-core SHARED ${qpid-proton-core-src})
+-add_dependencies (qpid-proton-core generated_c_files)
+-target_link_libraries (qpid-proton-core ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS})
+-set_target_properties (qpid-proton-core
+-  PROPERTIES
+-  VERSION   "${PN_LIB_CORE_VERSION}"
+-  SOVERSION "${PN_LIB_CORE_MAJOR_VERSION}"
+-  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
+-)
++#add_library (qpid-proton-core SHARED ${qpid-proton-core-src})
++#add_dependencies (qpid-proton-core generated_c_files)
++#target_link_libraries (qpid-proton-core ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS})
++#set_target_properties (qpid-proton-core
++#  PROPERTIES
++#  VERSION   "${PN_LIB_CORE_VERSION}"
++#  SOVERSION "${PN_LIB_CORE_MAJOR_VERSION}"
++#  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
++#)
  
- # Enable C++ now for examples and bindings subdirectories, but make it optional.
- enable_language(CXX OPTIONAL)
+ if (BUILD_STATIC_LIBS)
+   add_library (qpid-proton-core-static STATIC ${qpid-proton-core-src})
+@@ -472,14 +472,14 @@
+   ${qpid-proton-include-extra}
+ )
  
- # Enable testing
--enable_testing()
+-add_library (qpid-proton SHARED ${qpid-proton-src})
+-target_link_libraries (qpid-proton LINK_PRIVATE ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+-set_target_properties (qpid-proton
+-  PROPERTIES
+-  VERSION   "${PN_LIB_LEGACY_VERSION}"
+-  SOVERSION "${PN_LIB_LEGACY_MAJOR_VERSION}"
+-  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
+-)
++#add_library (qpid-proton SHARED ${qpid-proton-src})
++#target_link_libraries (qpid-proton LINK_PRIVATE ${SSL_LIB} ${SASL_LIB} ${TIME_LIB} ${PLATFORM_LIBS} ${PROACTOR_LIBS})
++#set_target_properties (qpid-proton
++#  PROPERTIES
++#  VERSION   "${PN_LIB_LEGACY_VERSION}"
++#  SOVERSION "${PN_LIB_LEGACY_MAJOR_VERSION}"
++#  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
++#)
+ 
+ if (BUILD_STATIC_LIBS)
+   add_library(qpid-proton-static STATIC ${qpid-proton-src})
+@@ -500,15 +500,15 @@
+ 
+ if (qpid-proton-proactor)
+   set(HAS_PROACTOR True)
+-  add_library (qpid-proton-proactor SHARED ${qpid-proton-proactor})
+-  target_link_libraries (qpid-proton-proactor  LINK_PUBLIC qpid-proton-core)
+-  target_link_libraries (qpid-proton-proactor  LINK_PRIVATE ${PLATFORM_LIBS} ${PROACTOR_LIBS})
+-  set_target_properties (qpid-proton-proactor
+-    PROPERTIES
+-    VERSION   "${PN_LIB_PROACTOR_VERSION}"
+-    SOVERSION "${PN_LIB_PROACTOR_MAJOR_VERSION}"
+-    LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
+-  )
++  #add_library (qpid-proton-proactor SHARED ${qpid-proton-proactor})
++  #target_link_libraries (qpid-proton-proactor  LINK_PUBLIC qpid-proton-core)
++  #target_link_libraries (qpid-proton-proactor  LINK_PRIVATE ${PLATFORM_LIBS} ${PROACTOR_LIBS})
++  #set_target_properties (qpid-proton-proactor
++  #  PROPERTIES
++  #  VERSION   "${PN_LIB_PROACTOR_VERSION}"
++  #  SOVERSION "${PN_LIB_PROACTOR_MAJOR_VERSION}"
++  #  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
++  #)
+   if (BUILD_STATIC_LIBS)
+     add_library (qpid-proton-proactor-static STATIC ${qpid-proton-proactor})
+   endif(BUILD_STATIC_LIBS)
+@@ -518,7 +518,7 @@
+ if (BUILD_STATIC_LIBS)
+   set(STATIC_LIBS qpid-proton-static qpid-proton-core-static)
+ endif()
+-install(TARGETS qpid-proton qpid-proton-core ${STATIC_LIBS}
++install(TARGETS ${STATIC_LIBS}
+   EXPORT  proton
+   RUNTIME DESTINATION bin
+   ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+@@ -538,11 +538,11 @@
+   if (BUILD_STATIC_LIBS)
+     set(STATIC_LIBS qpid-proton-proactor-static)
+   endif()
+-  install(TARGETS qpid-proton-proactor ${STATIC_LIBS}
+-    EXPORT  proton
+-    RUNTIME DESTINATION bin
+-    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+-    LIBRARY DESTINATION ${LIB_INSTALL_DIR})
++  #install(TARGETS qpid-proton-proactor ${STATIC_LIBS}
++  #  EXPORT  proton
++  #  RUNTIME DESTINATION bin
++  #  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
++  #  LIBRARY DESTINATION ${LIB_INSTALL_DIR})
+ 
+   # Install windows pdb files
+   if (MSVC)
+@@ -594,10 +594,10 @@
+   ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfigVersion.cmake
+   DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
+ 
+-add_subdirectory(docs)
+-add_subdirectory(examples)
+-add_subdirectory(tests)
+-add_subdirectory(tools)
++#add_subdirectory(docs)
++#add_subdirectory(examples)
++#add_subdirectory(tests)
++#add_subdirectory(tools)
+ 
+ install (DIRECTORY examples/
+          DESTINATION "${PROTON_SHARE}/examples/c"
+diff -ur qpid-proton-0.26.0/CMakeLists.txt qpid-proton-patched/CMakeLists.txt
+--- qpid-proton-0.26.0/CMakeLists.txt	2018-10-04 04:09:02.000000000 -0600
++++ qpid-proton-patched/CMakeLists.txt	2019-03-25 17:32:41.521213312 -0600
+@@ -24,22 +24,22 @@
+ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/Modules")
+ set (CMAKE_THREAD_PREFER_PTHREAD TRUE)
+ 
 -include (CTest)
-+#enable_testing()
 +#include (CTest)
+ include (CheckLanguage)
+ include (CheckLibraryExists)
+ include (CheckSymbolExists)
+ include (CheckPythonModule)
  
- # Pull in local cmake modules
- set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/Modules/")
-@@ -141,7 +142,7 @@ set (BINDINGS_DIR ${LIB_INSTALL_DIR}/proton/bindings)
+-find_package (OpenSSL)
++#find_package (OpenSSL)
+ find_package (Threads)
+ find_package (PythonInterp REQUIRED)
+-find_package (SWIG)
+-find_package (CyrusSASL)
++#find_package (SWIG)
++#find_package (CyrusSASL)
+ 
+-enable_testing ()
++#enable_testing ()
+ 
+ # Set up runtime checks (valgrind, sanitizers etc.)
+-include(tests/RuntimeCheck.cmake)  
++# include(tests/RuntimeCheck.cmake)  
+ 
+ ## Variables used across components
+ 
+@@ -272,7 +272,7 @@
  
  set (SYSINSTALL_BINDINGS OFF CACHE BOOL "If SYSINSTALL_BINDINGS is OFF then proton bindings will be installed underneath ${BINDINGS_DIR} and each user will need to modify their interpreter configuration to load the appropriate binding. If SYSINSTALL_BINDINGS is ON, then each language interpreter will be queried for the appropriate directory and proton bindings will be installed and available system wide with no additional per user configuration.")
  
--set (BINDING_LANGS PERL PHP PYTHON RUBY)
-+#set (BINDING_LANGS PERL PHP PYTHON RUBY)
+-set (BINDING_LANGS PYTHON RUBY)
++#set (BINDING_LANGS PYTHON RUBY)
  
  foreach (LANG ${BINDING_LANGS})
    set (SYSINSTALL_${LANG} OFF CACHE BOOL "Install ${LANG} bindings into interpreter specified location.")
-@@ -156,10 +157,10 @@ set (PROTON_SHARE ${SHARE_INSTALL_DIR}/proton-${PN_VERSION})
- # End of variables used during install
- 
- # Check for valgrind here so tests under proton-c/ and examples/ can use it.
--find_program(VALGRIND_EXE valgrind DOC "Location of the valgrind program")
-+#find_program(VALGRIND_EXE valgrind DOC "Location of the valgrind program")
- mark_as_advanced (VALGRIND_EXE)
- 
--option(ENABLE_VALGRIND "Use valgrind to detect run-time problems" ON)
-+#option(ENABLE_VALGRIND "Use valgrind to detect run-time problems" ON)
- if (ENABLE_VALGRIND)
-   if (NOT VALGRIND_EXE)
-     message(STATUS "Can't locate the valgrind command; no run-time error detection")
-@@ -171,7 +172,7 @@ if (ENABLE_VALGRIND)
- endif (ENABLE_VALGRIND)
- 
- add_subdirectory(proton-c)
--add_subdirectory(examples)
-+#add_subdirectory(examples)
- 
- install (FILES LICENSE README.md
-          DESTINATION ${PROTON_SHARE})
-diff --git a/examples/cpp/CMakeLists.txt b/examples/cpp/CMakeLists.txt
-index 304d899..f4877b4 100644
---- a/examples/cpp/CMakeLists.txt
-+++ b/examples/cpp/CMakeLists.txt
-@@ -17,6 +17,7 @@
- # under the License.
- #
- 
-+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
- find_package(ProtonCpp REQUIRED)
- 
- include_directories(${ProtonCpp_INCLUDE_DIRS})
-diff --git a/proton-c/CMakeLists.txt b/proton-c/CMakeLists.txt
-index 8edb661..dc7b99c 100644
---- a/proton-c/CMakeLists.txt
-+++ b/proton-c/CMakeLists.txt
-@@ -22,24 +22,24 @@ include(CheckSymbolExists)
- 
- include(soversion.cmake)
- 
--add_custom_target(docs)
--add_custom_target(doc DEPENDS docs)
-+#add_custom_target(docs)
-+#add_custom_target(doc DEPENDS docs)
- 
- # Set the default SSL/TLS implementation
--find_package(OpenSSL)
-+#find_package(OpenSSL)
- find_package(PythonInterp REQUIRED)
--find_package(SWIG)
-+#find_package(SWIG)
- # FindSwig.cmake "forgets" make its outputs advanced like a good citizen
- mark_as_advanced(SWIG_DIR SWIG_EXECUTABLE SWIG_VERSION)
- 
- # See if Cyrus SASL is available
--find_library(CYRUS_SASL_LIBRARY sasl2)
--find_path(CYRUS_SASL_INCLUDE_DIR sasl/sasl.h PATH_SUFFIXES include)
--find_package_handle_standard_args(CyrusSASL DEFAULT_MSG CYRUS_SASL_LIBRARY CYRUS_SASL_INCLUDE_DIR)
-+#find_library(CYRUS_SASL_LIBRARY sasl2)
-+#find_path(CYRUS_SASL_INCLUDE_DIR sasl/sasl.h PATH_SUFFIXES include)
-+#find_package_handle_standard_args(CyrusSASL DEFAULT_MSG CYRUS_SASL_LIBRARY CYRUS_SASL_INCLUDE_DIR)
- mark_as_advanced(CYRUS_SASL_LIBRARY CYRUS_SASL_INCLUDE_DIR)
- 
- # Find saslpasswd2 executable to generate test config
--find_program(SASLPASSWD_EXE saslpasswd2 DOC "Program used to make SASL user db for testing")
-+#find_program(SASLPASSWD_EXE saslpasswd2 DOC "Program used to make SASL user db for testing")
- mark_as_advanced(SASLPASSWD_EXE)
- 
- if(WIN32 AND NOT CYGWIN)
-@@ -315,8 +315,8 @@ pn_absolute_install_dir(EXEC_PREFIX "." ${CMAKE_INSTALL_PREFIX})
- pn_absolute_install_dir(LIBDIR ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX})
- pn_absolute_install_dir(INCLUDEDIR ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX})
- 
--add_subdirectory(docs/api)
--add_subdirectory(../tests/tools/apps/c ../tests/tools/apps/c)
-+#add_subdirectory(docs/api)
-+#add_subdirectory(../tests/tools/apps/c ../tests/tools/apps/c)
- 
- # for full source distribution:
- set (qpid-proton-platform-all
-@@ -507,7 +507,7 @@ if (BUILD_WITH_CXX)
- endif (BUILD_WITH_CXX)
- 
- add_library (
--  qpid-proton-core SHARED
-+  qpid-proton-core STATIC
-   ${qpid-proton-core}
-   ${qpid-proton-layers}
-   ${qpid-proton-platform}
-@@ -527,7 +527,7 @@ set_target_properties (
-   )
- 
- add_library(
--  qpid-proton SHARED
-+  qpid-proton STATIC
-   # Proton Core
-   ${qpid-proton-core}
-   ${qpid-proton-layers}
-@@ -629,7 +629,7 @@ install (FILES
- 
- # c tests:
- 
--add_subdirectory(src/tests)
-+#add_subdirectory(src/tests)
- 
- if (CMAKE_SYSTEM_NAME STREQUAL Windows)
-   # No change needed for windows already use correct separator
-@@ -712,7 +712,7 @@ if (BUILD_PYTHON)
- 
- endif (BUILD_PYTHON)
- 
--find_program(RUBY_EXE "ruby")
-+#find_program(RUBY_EXE "ruby")
- if (RUBY_EXE AND BUILD_RUBY)
-   set (rb_root "${pn_test_root}/ruby")
-   set (rb_src "${CMAKE_CURRENT_SOURCE_DIR}/bindings/ruby")
-@@ -751,8 +751,8 @@ if (RUBY_EXE AND BUILD_RUBY)
-   else (DEFAULT_RUBY_TESTING)
-     message(STATUS "Skipping Ruby tests: missing dependencies")
-   endif (DEFAULT_RUBY_TESTING)
--else (RUBY_EXE)
--  message (STATUS "Cannot find ruby, skipping ruby tests")
-+#else (RUBY_EXE)
-+#  message (STATUS "Cannot find ruby, skipping ruby tests")
+@@ -327,7 +327,7 @@
  endif()
- 
- mark_as_advanced (RUBY_EXE RSPEC_EXE)
-diff --git a/proton-c/bindings/CMakeLists.txt b/proton-c/bindings/CMakeLists.txt
-index 6b88384..d1a50a5 100644
---- a/proton-c/bindings/CMakeLists.txt
-+++ b/proton-c/bindings/CMakeLists.txt
-@@ -19,14 +19,14 @@
- 
- # Add bindings that do not require swig here - the directory name must be the same as the binding name
- # See below for swig bindings
--set(BINDINGS javascript cpp go)
-+set(BINDINGS cpp)
- 
- # Prerequisites for javascript.
- #
- # It uses a C/C++ to JavaScript cross-compiler called emscripten (https://github.com/kripken/emscripten). Emscripten takes C/C++
- # and compiles it into a highly optimisable subset of JavaScript called asm.js (http://asmjs.org/) that can be
- # aggressively optimised and run at near-native speed (usually between 1.5 to 10 times slower than native C/C++).
--find_package(Emscripten)
-+#find_package(Emscripten)
- if (EMSCRIPTEN_FOUND)
-   set (DEFAULT_JAVASCRIPT ON)
- endif (EMSCRIPTEN_FOUND)
-@@ -37,7 +37,7 @@ if (CMAKE_CXX_COMPILER)
- endif (CMAKE_CXX_COMPILER)
  
  # Prerequisites for Go
 -find_program(GO_EXE go)
 +#find_program(GO_EXE go)
  mark_as_advanced(GO_EXE)
  if (GO_EXE)
-   if(WIN32)
-diff --git a/proton-c/bindings/cpp/CMakeLists.txt b/proton-c/bindings/cpp/CMakeLists.txt
-index 0cc4024..796fe29 100644
---- a/proton-c/bindings/cpp/CMakeLists.txt
-+++ b/proton-c/bindings/cpp/CMakeLists.txt
-@@ -16,7 +16,7 @@
- # specific language governing permissions and limitations
- # under the License.
- #
--
-+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
- include(cpp.cmake) # Compiler checks
- 
- include_directories(
-@@ -89,7 +89,7 @@ set_source_files_properties (
-   COMPILE_FLAGS "${LTO}"
-   )
+   set (DEFAULT_GO ON)
+diff -ur qpid-proton-0.26.0/cpp/CMakeLists.txt qpid-proton-patched/cpp/CMakeLists.txt
+--- qpid-proton-0.26.0/cpp/CMakeLists.txt	2018-10-04 04:09:02.000000000 -0600
++++ qpid-proton-patched/cpp/CMakeLists.txt	2019-03-25 17:32:41.521213312 -0600
+@@ -174,25 +174,25 @@
+   set (CMAKE_DEBUG_POSTFIX "d")
+ endif ()
  
 -add_library(qpid-proton-cpp SHARED ${qpid-proton-cpp-source})
-+add_library(qpid-proton-cpp STATIC ${qpid-proton-cpp-source})
++#add_library(qpid-proton-cpp SHARED ${qpid-proton-cpp-source})
+ if(BUILD_STATIC_LIBS)
+   add_library(qpid-proton-cpp-static STATIC ${qpid-proton-cpp-source})
+ endif(BUILD_STATIC_LIBS)
  
- target_link_libraries (qpid-proton-cpp ${PLATFORM_LIBS} qpid-proton)
+-target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} qpid-proton-core qpid-proton-proactor ${CONNECT_CONFIG_LIBS})
++#target_link_libraries (qpid-proton-cpp LINK_PRIVATE ${PLATFORM_LIBS} qpid-proton-core qpid-proton-proactor ${CONNECT_CONFIG_LIBS})
  
-@@ -120,8 +120,8 @@ endif (MSVC)
+-set_target_properties (
+-  qpid-proton-cpp
+-  PROPERTIES
+-  LINKER_LANGUAGE CXX
+-  VERSION   "${PN_LIB_CPP_VERSION}"
+-  SOVERSION "${PN_LIB_CPP_MAJOR_VERSION}"
+-  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
+-  )
++#set_target_properties (
++#  qpid-proton-cpp
++#  PROPERTIES
++#  LINKER_LANGUAGE CXX
++#  VERSION   "${PN_LIB_CPP_VERSION}"
++#  SOVERSION "${PN_LIB_CPP_MAJOR_VERSION}"
++#  LINK_FLAGS "${CATCH_UNDEFINED} ${LTO}"
++#  )
+ 
+ ## Install
+ 
+-install(TARGETS qpid-proton-cpp
++install(TARGETS qpid-proton-cpp-static
+   EXPORT  proton-cpp
+   RUNTIME DESTINATION bin
+   ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+@@ -208,12 +208,12 @@
  
  install (DIRECTORY "include/proton" DESTINATION ${INCLUDE_INSTALL_DIR} FILES_MATCHING PATTERN "*.hpp")
+ install (FILES "${CMAKE_CURRENT_BINARY_DIR}/config_presets.hpp" DESTINATION "${INCLUDE_INSTALL_DIR}/proton/internal")
+-install (DIRECTORY "examples/"
+-  DESTINATION "${PROTON_SHARE}/examples/cpp"
+-  USE_SOURCE_PERMISSIONS
+-  PATTERN "ProtonCppConfig.cmake" EXCLUDE)
++#install (DIRECTORY "examples/"
++#  DESTINATION "${PROTON_SHARE}/examples/cpp"
++#  USE_SOURCE_PERMISSIONS
++#  PATTERN "ProtonCppConfig.cmake" EXCLUDE)
  
--add_subdirectory(docs)
--add_subdirectory(${CMAKE_SOURCE_DIR}/tests/tools/apps/cpp ${CMAKE_BINARY_DIR}/tests/tools/apps/cpp)
-+#add_subdirectory(docs)
-+#add_subdirectory(${CMAKE_SOURCE_DIR}/tests/tools/apps/cpp ${CMAKE_BINARY_DIR}/tests/tools/apps/cpp)
+-add_subdirectory(examples)
++#add_subdirectory(examples)
+ add_subdirectory(docs)
  
  # Pkg config file
- configure_file(
-@@ -171,12 +171,12 @@ macro(add_cpp_test test)
-   endif ()
- endmacro(add_cpp_test)
+@@ -267,28 +267,28 @@
+   set(test_env ${test_env} "PATH=$<TARGET_FILE_DIR:qpid-proton>")
+ endif()
  
+-macro(add_cpp_test test)
+-  add_executable (${test} src/${test}.cpp)
+-  target_link_libraries (${test} qpid-proton-cpp ${PLATFORM_LIBS})
+-  add_test (NAME cpp-${test}
+-    COMMAND ${PN_ENV_SCRIPT} -- ${test_env}  ${TEST_EXE_PREFIX_CMD} $<TARGET_FILE:${test}> ${ARGN})
+-endmacro(add_cpp_test)
+-
 -add_cpp_test(codec_test)
-+#add_cpp_test(codec_test)
- #add_cpp_test(engine_test)
--add_cpp_test(thread_safe_test)
+-add_cpp_test(connection_driver_test)
 -add_cpp_test(interop_test ${CMAKE_SOURCE_DIR}/tests)
 -add_cpp_test(message_test)
+-add_cpp_test(map_test)
 -add_cpp_test(scalar_test)
 -add_cpp_test(value_test)
 -add_cpp_test(container_test)
 -add_cpp_test(url_test)
-+#add_cpp_test(thread_safe_test)
+-add_cpp_test(reconnect_test)
+-add_cpp_test(link_test)
+-if (ENABLE_JSONCPP)
+-  add_cpp_test(connect_config_test)
+-  target_link_libraries(connect_config_test qpid-proton-core) # For pn_sasl_enabled
+-  set_tests_properties(cpp-connect_config_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+-  # Test data and output directories for connect_config_test
+-  file(COPY  "${CMAKE_CURRENT_SOURCE_DIR}/testdata" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+-endif()
++#macro(add_cpp_test test)
++#  add_executable (${test} src/${test}.cpp)
++#  target_link_libraries (${test} qpid-proton-cpp ${PLATFORM_LIBS})
++#  add_test (NAME cpp-${test}
++#    COMMAND ${PN_ENV_SCRIPT} -- ${test_env}  ${TEST_EXE_PREFIX_CMD} $<TARGET_FILE:${test}> ${ARGN})
++#endmacro(add_cpp_test)
++#
++#add_cpp_test(codec_test)
++#add_cpp_test(connection_driver_test)
 +#add_cpp_test(interop_test ${CMAKE_SOURCE_DIR}/tests)
 +#add_cpp_test(message_test)
++#add_cpp_test(map_test)
 +#add_cpp_test(scalar_test)
 +#add_cpp_test(value_test)
 +#add_cpp_test(container_test)
 +#add_cpp_test(url_test)
-diff --git a/proton-c/bindings/cpp/docs/CMakeLists.txt b/proton-c/bindings/cpp/docs/CMakeLists.txt
-index d512d15..8576867 100644
---- a/proton-c/bindings/cpp/docs/CMakeLists.txt
-+++ b/proton-c/bindings/cpp/docs/CMakeLists.txt
-@@ -17,7 +17,7 @@
- # under the License.
- #
++#add_cpp_test(reconnect_test)
++#add_cpp_test(link_test)
++#if (ENABLE_JSONCPP)
++#  add_cpp_test(connect_config_test)
++#  target_link_libraries(connect_config_test qpid-proton-core) # For pn_sasl_enabled
++#  set_tests_properties(cpp-connect_config_test PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
++#  # Test data and output directories for connect_config_test
++#  file(COPY  "${CMAKE_CURRENT_SOURCE_DIR}/testdata" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
++#endif()
+diff -ur qpid-proton-0.26.0/cpp/include/proton/url.hpp qpid-proton-patched/cpp/include/proton/url.hpp
+--- qpid-proton-0.26.0/cpp/include/proton/url.hpp	2018-10-04 04:09:02.000000000 -0600
++++ qpid-proton-patched/cpp/include/proton/url.hpp	2019-03-25 17:33:50.956058757 -0600
+@@ -40,7 +40,6 @@
+ /// An error encountered during URL parsing.
  
--find_package(Doxygen)
-+#find_package(Doxygen)
- 
- if (DOXYGEN_FOUND)
-   configure_file (
-diff --git a/proton-c/docs/api/CMakeLists.txt b/proton-c/docs/api/CMakeLists.txt
-index 7756e48..71ebb93 100644
---- a/proton-c/docs/api/CMakeLists.txt
-+++ b/proton-c/docs/api/CMakeLists.txt
-@@ -17,7 +17,7 @@
- # under the License.
- #
- 
--find_package(Doxygen)
-+#find_package(Doxygen)
- if (DOXYGEN_FOUND)
-   configure_file (${CMAKE_CURRENT_SOURCE_DIR}/user.doxygen.in
-                   ${CMAKE_CURRENT_BINARY_DIR}/user.doxygen)
--- 
-2.7.4
-
+ struct
+-PN_CPP_DEPRECATED("Use a third-party URL library")
+ PN_CPP_CLASS_EXTERN url_error : public error {
+     /// @cond INTERNAL
+     /// Construct a URL error with a message.
+@@ -62,7 +61,7 @@
+ ///
+ /// - Path is normally used as a link source or target address.  On a
+ ///   broker it typically corresponds to a queue or topic name.
+-class PN_CPP_DEPRECATED("Use a third-party URL library") url {
++class url {
+   public:
+     static const std::string AMQP;     ///< "amqp" prefix
+     static const std::string AMQPS;    ///< "amqps" prefix

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -18,7 +18,7 @@
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 2
 #define CLIENT_VERSION_MINOR 0
-#define CLIENT_VERSION_REVISION 0
+#define CLIENT_VERSION_REVISION 2
 #define CLIENT_VERSION_BUILD 50
 
 //! Set to true for release, false for prerelease or test build

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -503,22 +503,26 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
 void CNode::CloseSocketDisconnect()
 {
     fDisconnect = true;
-
     {
         LOCK(cs_hSocket);
-
         if (hSocket != INVALID_SOCKET)
         {
-            LogPrint("net", "disconnecting peer=%d\n", id);
-
+            try
+            {
+                LogPrint("net", "disconnecting peer=%d\n", id);
+            }
+            catch(std::bad_alloc&)
+            {
+                // when the node is shutting down, the call above might use invalid memory resulting in a 
+                // std::bad_alloc exception when instantiating internal objs for handling log category
+                LogPrintf("(node is probably shutting down) disconnecting peer=%d\n", id);
+            }
             if (ssl)
             {
                 tlsmanager.waitFor(SSL_SHUTDOWN, hSocket, ssl, (DEFAULT_CONNECT_TIMEOUT / 1000));
-
                 SSL_free(ssl);
                 ssl = NULL;
             }
-
             CloseSocket(hSocket);
         }
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -56,7 +56,7 @@ extern char ASSETCHAINS_SYMBOL[SAFECOIN_ASSETCHAIN_MAXLEN];
 uint32_t safecoin_segid32(char *coinaddr);
 int64_t safecoin_coinsupply(int64_t *zfundsp,int64_t *sproutfundsp,int32_t height);
 int32_t notarizedtxid_height(char *dest,char *txidstr,int32_t *safenotarized_heightp);
-#define SAFECOIN_VERSION "2.0.0"
+#define SAFECOIN_VERSION "2.0.2"
 #define VERUS_VERSION "0.4.0g"
 extern uint16_t ASSETCHAINS_P2PPORT,ASSETCHAINS_RPCPORT;
 extern uint32_t ASSETCHAINS_CC;


### PR DESCRIPTION
 Cherry picked commits from the following upstream PRs:
[zcash/zcash#3809](https://github.com/zcash/zcash/pull/3809)
[zcash/zcash#3918](https://github.com/zcash/zcash/pull/3918)
[zcash/zcash#3919](https://github.com/zcash/zcash/pull/3919)

 Updating:

 * Boost from 1.66.0 to 1.70.0
 * OpenSSL From 1.1.0h to 1.1.1a
* Proton from 0.17.0 to 0.26.0
* Rust from 1.28.0 to 1.32.0

Additionally updated:

* OpenSSL to 1.1.1c

Build tests were performed for Linux AMD64 with --enable-proton, and Windows without proton.

For the OpenSSL upgrade the following was successfully tested:

* automatic RSA self-signed certificate generation
* Incoming and outgoing TLS connections with self-signed and valid SSL certificates to new and old nodes
* tlsvalidate=1 rejecting connections with self-signed certificates

With OpenSSL 1.1.1 safecoind will default to TLS1.3 connections, but still accept TLS1.2 connections keeping backwards compatibility.

CLIENT_VERSION up to 2.0.2