### PR TITLE
Update validator.rs

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1235,7 +1235,7 @@ fn wait_for_supermajority(
     for i in 1.. {
         if i % 10 == 1 {
             info!(
-                "Waiting for 80% of activated stake at slot {} to be in gossip...",
+                "Waiting for 50% of activated stake at slot {} to be in gossip...",
                 bank.slot()
             );
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1235,7 +1235,7 @@ fn wait_for_supermajority(
     for i in 1.. {
         if i % 10 == 1 {
             info!(
-                "Waiting for 50% of activated stake at slot {} to be in gossip...",
+                "Waiting for 40% of activated stake at slot {} to be in gossip...",
                 bank.slot()
             );
         }


### PR DESCRIPTION
The info log reports 80% of active stake required in gossip however only 50% of activated stake is required, correction only necessary for accurate logging purposes.
