### PR TITLE
Adjust cost per signature

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -129,7 +129,8 @@ pub const MAX_MULTIPLE_ACCOUNTS: usize = 100;
 pub const NUM_LARGEST_ACCOUNTS: usize = 20;
 
 // Validators that are this number of slots behind are considered delinquent
-pub const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
+// increased by 50% for Safecoin to complement lowered hardware requirements
+pub const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 192;
 
 impl RpcRequest {
     pub(crate) fn build_request_json(self, id: u64, params: Value) -> Value {

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -85,8 +85,11 @@ pub struct FeeRateGovernor {
     // What portion of collected fees are to be destroyed, as a fraction of std::u8::MAX
     pub burn_percent: u8,
 }
-
-pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 200_000;
+// Adjusted to match emission schedule 
+// Range is min 50% to 1000% of DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE
+// Solana Target: 50 x 10.000 = 500.000 Lamports per Slot (min 250.000 - max 5.000.000)
+// Safecoin Target: 10 x 50.000 = 500.000 Lamports per Slot (min 250.000 - max 5.000.000)
+pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 50_000;
 pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: u64 = 10 * DEFAULT_MS_PER_SLOT;
 
 // Percentage of tx fees to burn


### PR DESCRIPTION
Lowered cost per signature

 from

 Safecoin Target: 10 x 200.000 = 2.000.000 Lamports per Slot (min 1.000.000 - max 20.000.000)

to

 Safecoin Target: 10 x 50.000 = 500.000 Lamports per Slot (min 250.000 - max 5.000.000)

This is an adjustment in correlation with PR #8 

