### PR TITLE
Update mod.rs

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -18,6 +18,8 @@ use solana_sdk::{
     slot_hashes::SlotHash,
     sysvar::clock::Clock,
 };
+use chrono::prelude::*;
+extern crate chrono;
 use std::boxed::Box;
 use std::cmp::Ordering;
 use std::collections::{HashSet, VecDeque};
@@ -722,13 +724,20 @@ log::trace!("last_hashy: {}", slot_hashes[0].1);
 log::trace!("last_hashzy: {}", slot_hashes[0].0);
 log::trace!("P: {}", authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10);
 
-
+    let dt = Local::now();
+    if dt.timestamp_millis() > 1625793876000 {
 if ( ( clock.slot % 10 ) as usize != ( ( ( clock.slot % 9 + 1 ) as usize * ( authorized_voter.to_string().chars().last().unwrap() as usize + slot_hashes[0].1.to_string().chars().last().unwrap() as usize ) / 10 ) as usize + authorized_voter.to_string().chars().last().unwrap() as usize + slot_hashes[0].1.to_string().chars().last().unwrap() as usize ) % 10 as usize ) {
 if authorized_voter.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu" {
 	      return Err(InstructionError::UninitializedAccount);
               }
 	    }
-
+      }else{
+if (slot_hashes[0].1.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) != (authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) {
+	if authorized_voter.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu" {
+	      return Err(InstructionError::UninitializedAccount);
+              }
+	    }
+      }
 
 log::info!("authorized_voter: {}", &authorized_voter);
     verify_authorized_signer(&authorized_voter, signers)?;

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -723,7 +723,7 @@ log::trace!("last_hashzy: {}", slot_hashes[0].0);
 log::trace!("P: {}", authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10);
 
 
-if (slot_hashes[0].1.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) != (authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) {
+if ( ( clock.slot % 10 ) as usize != ( ( ( clock.slot % 9 + 1 ) as usize * ( authorized_voter.to_string().chars().last().unwrap() as usize + slot_hashes[0].1.to_string().chars().last().unwrap() as usize ) / 10 ) as usize + authorized_voter.to_string().chars().last().unwrap() as usize + slot_hashes[0].1.to_string().chars().last().unwrap() as usize ) % 10 as usize ) {
 if authorized_voter.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu" {
 	      return Err(InstructionError::UninitializedAccount);
               }


### PR DESCRIPTION
Improve the efficiency and distribution of voting and vote group selection together with the creation of dynamically generated group memberships that provides an evenly distributed vote spread allow/deny 10%/90%. This will improve the spread of vote frequency and reduce validator delinquency rates. To be used in conjunction with replay_stage PR.
