### PR TITLE
Uniform vote distribution SHA256

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -40,6 +40,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     timing::timestamp,
     transaction::Transaction,
+    safecoin
 };
 use solana_vote_program::{vote_instruction, vote_state::Vote};
 use std::{
@@ -1219,21 +1220,10 @@ impl ReplayStage {
                 return;
             };
 
-
-log::trace!("authorized_voter_pubkey {}", authorized_voter_pubkey);
-log::trace!("authorized_voter_pubkey_string {}", authorized_voter_pubkey.to_string());
-log::trace!("vote_hash: {}", vote.hash);
-log::trace!("H: {}", bank.last_blockhash().to_string().find("T").unwrap_or(3) % 10);
-log::trace!("P: {}", authorized_voter_pubkey.to_string().find("T").unwrap_or(3));
-
-
-	if (vote.hash.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) != (authorized_voter_pubkey.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) && authorized_voter_pubkey.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu"  {
-   		warn!(
-                    "Vote account has no authorized voter for slot.  Unable to vote"
-		);
-                return;
-		}
-
+        if safecoin::is_voting_denied(&bank.slot(),&authorized_voter_pubkey,&vote.hash) {
+            warn!("Vote account has no authorized voter for slot.  Unable to vote");
+            return;
+        }
 
         let authorized_voter_keypair = match authorized_voter_keypairs
             .iter()

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -17,6 +17,7 @@ use solana_sdk::{
     rent::Rent,
     slot_hashes::SlotHash,
     sysvar::clock::Clock,
+    safecoin
 };
 use std::boxed::Box;
 use std::cmp::Ordering;
@@ -716,21 +717,10 @@ pub fn process_vote<S: std::hash::BuildHasher>(
     let mut vote_state = versioned.convert_to_current();
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch);
 
+    if safecoin::is_voting_denied(&clock.slot,&authorized_voter,&slot_hashes[0].1) {
+	    return Err(InstructionError::UninitializedAccount);
+	}
 
-log::trace!("slot: {}", clock.slot);
-log::trace!("last_hashy: {}", slot_hashes[0].1);
-log::trace!("last_hashzy: {}", slot_hashes[0].0);
-log::trace!("P: {}", authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10);
-
-
-if (slot_hashes[0].1.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) != (authorized_voter.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) {
-if authorized_voter.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu" {
-	      return Err(InstructionError::UninitializedAccount);
-              }
-	    }
-
-
-log::info!("authorized_voter: {}", &authorized_voter);
     verify_authorized_signer(&authorized_voter, signers)?;
 
     vote_state.process_vote(vote, slot_hashes, clock.epoch)?;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -34,6 +34,7 @@ pub mod program_utils;
 pub mod pubkey;
 pub mod recent_blockhashes_account;
 pub mod rpc_port;
+pub mod safecoin;
 pub mod secp256k1_instruction;
 pub mod shred_version;
 pub mod signature;

--- a/sdk/src/safecoin.rs
+++ b/sdk/src/safecoin.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "full")]
+
+use sha2::{Sha256,Digest};
+
+use solana_sdk::{
+    hash::Hash,
+    pubkey::Pubkey
+};
+
+pub const SC_FALLBACK_VALIDATOR_STR: &str = "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu";
+pub const SC_FALLBACK_VALIDATOR: &Pubkey = &Pubkey::new_from_array([104, 147, 193, 98, 234, 13, 57, 77,
+                                                                    158, 79, 114, 179, 99, 46, 189, 80,
+                                                                    207, 135, 95,179,175,254,58,186,99,
+                                                                    134,161,27,27,136,224,204]);
+
+// Slot where a version of a function replace the previous one.
+// TODO: Replace with proper slot height before going in production.
+const SC_IS_VOTING_DENIED_V3: &u64 = &2u64;
+const SC_IS_VOTING_DENIED_V2: &u64 = &1u64;
+const SC_IS_VOTING_DENIED_V1: &u64 = &0u64;
+
+pub fn is_voting_denied(slot:&u64, voter_pubkey: &Pubkey,vote_hash: &Hash) -> bool {
+    if slot >= SC_IS_VOTING_DENIED_V3 {
+      // Uniform distribution of vote denial among validators.
+      let mut hasher  = Sha256::new();
+      hasher.update(voter_pubkey.to_bytes());
+      hasher.update(vote_hash.to_bytes());
+      let hash256 = hasher.finalize();
+
+      // Convert the 256 bits hash to u32 by arbitraty selecting 4 bytes.
+      // This is portable (not affected by endianess).
+      let hash32 = ((hash256[0] as u32) <<   0) |
+                   ((hash256[1] as u32) <<   8) |
+                   ((hash256[2] as u32) <<  16) |
+                   ((hash256[3] as u32) <<  24);
+
+      // Deny voting 90% of the time, except for fallback validator.
+      return (hash32%10) != 0 && voter_pubkey != SC_FALLBACK_VALIDATOR;
+
+    } else if slot >= SC_IS_VOTING_DENIED_V2 {
+      // Do not change for backward compatibility.
+      return  (  ( slot % 10 ) as usize !=
+                 ( ( ( slot % 9 + 1 ) as usize * ( voter_pubkey.to_string().chars().last().unwrap() as usize + vote_hash.to_string().chars().last().unwrap() as usize ) / 10 ) as usize +
+                    voter_pubkey.to_string().chars().last().unwrap() as usize + vote_hash.to_string().chars().last().unwrap() as usize
+                 ) % 10 as usize
+              ) && voter_pubkey.to_string() != SC_FALLBACK_VALIDATOR_STR;
+    } else {
+      // Do not change for backward compatibility.
+      return (vote_hash.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) !=
+             (voter_pubkey.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) &&
+             voter_pubkey.to_string() != SC_FALLBACK_VALIDATOR_STR
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_program::hash::HASH_BYTES;
+    use std::str::FromStr;
+
+    #[test]
+    fn safecoin_fallback() {
+        // Verify server fallback is never denied voting.
+
+        // Build fallback pubkey from string, verify public constant is same.
+        let fallback_pubkey = Pubkey::from_str(SC_FALLBACK_VALIDATOR_STR).unwrap();
+        assert!( SC_FALLBACK_VALIDATOR == &fallback_pubkey );
+
+        // Build a voter and slot combination known to be denied with all versions (up to now).
+        let vote_hash = Hash::new_from_array([11u8; HASH_BYTES] );
+        let denied_pubkey = Pubkey::new_from_array([8u8; HASH_BYTES]);
+
+        // Test behavior by changing the denied pubkey with the fallback one.
+        // Repeat test with older versions.
+        {
+            let slot: &u64 = SC_IS_VOTING_DENIED_V3;
+            assert_eq!( is_voting_denied(&slot,&denied_pubkey,&vote_hash), true );
+            assert_eq!( is_voting_denied(&slot,&fallback_pubkey,&vote_hash), false );
+        }
+        {
+            let slot: &u64 = SC_IS_VOTING_DENIED_V2;
+            assert_eq!( is_voting_denied(&slot,&denied_pubkey,&vote_hash), true );
+            assert_eq!( is_voting_denied(&slot,&fallback_pubkey,&vote_hash), false );
+        }
+        {
+            let slot: &u64 = SC_IS_VOTING_DENIED_V1;
+            assert_eq!( is_voting_denied(&slot,&denied_pubkey,&vote_hash), true );
+            assert_eq!( is_voting_denied(&slot,&fallback_pubkey,&vote_hash), false );
+        }
+    }
+
+    //#[test]
+    //fn safecoin_profiling() {
+    // Not really a test, just code to help profiling some functions.
+    //    let vote_hash = Hash::new_from_array([11u8; HASH_BYTES] );
+    //    let mut n_denied: u32 = 0;
+    //    let iter:u32 = 10000;
+    //    for _ in 0..iter {
+    //      let voter_pubkey = Pubkey::new_unique();
+    //      if is_voting_denied(SC_IS_VOTING_DENIED_V1, &voter_pubkey, &vote_hash)  { n_denied += 1; }
+    //    }
+    //    println!("n_denied={}/{}%", n_denied, iter );
+    //    assert!(false);
+    //}
+}


### PR DESCRIPTION
### Important: This code requires further change to set the slot where each algo becomes active. Only unit test done, no testnet. Wanted to put this here for early feedback.

**Goal**
Replace consensus code responsible to allow/deny 10/90% of the votes.

This PR uses a hash function (SHA256) to deliver uniform distribution of "vote denial" among the validators.

**Implementation**
voter address and vote hash (each 32 bytes) are fed as input to SHA256.

This combination of inputs deny voting to a different subset of validators for each vote.

The 256bits output of SHA256 is truncated to a smaller 32bits hash (hash32).

hash32%10 != 0 is used for the 90% selection.

A new solana_sdk::safecoin module has been created for code reuse.

**New Unit Test**
cargo test --package solana-sdk safecoin

**Profiling**
Measurements done with 10K safecoin::is_voter_denied() calls. 
Each call with a different voter address. Slot and vote hash kept constant while profiling.

V1 is the find(x) algo
V2 is the algo from PR #11 and #12 
V3 is SHA256 of 64 bytes (vote hash and voter address).

_Total Execution Time_
V1 = ~2.04s (204us per call)
V2 = ~3.37s (337us per call)
V3 = ~0.48s ( 48us per call)

_Denied %_
V1 = ~89.97%
V2 = ~96.56%
V3 = ~89.81%

Likely the Base58 encoding done by to_string() affects performance of V1 and V2.

Solana uses a SHA2 lib that supports hardware acceleration.
  https://en.wikipedia.org/wiki/Intel_SHA_extensions

Measurements done on a setup without hardware acceleration (Xeon E5-2620@2.10 Ghz release in 2012).

As usual, benchmarks are full of caveats.


