### PR TITLE
Yet another vote optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 log-*.txt
 log-*/
 
-# intellij files
+# intellij files:
 /.idea/
 /solana.iml
 /.vscode/
@@ -27,3 +27,4 @@ log-*/
 /spl_*.so
 
 .DS_Store
+/test-ledger/

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1225,14 +1225,23 @@ log::trace!("authorized_voter_pubkey_string {}", authorized_voter_pubkey.to_stri
 log::trace!("vote_hash: {}", vote.hash);
 log::trace!("H: {}", bank.last_blockhash().to_string().find("T").unwrap_or(3) % 10);
 log::trace!("P: {}", authorized_voter_pubkey.to_string().find("T").unwrap_or(3));
+  
+    let group_gen = bank.epoch_stakes(bank.epoch()).unwrap().get_group_genr();
+    let in_group = group_gen.in_group_for_seed(vote.slots[0],*vote_account_pubkey);
 
+    let normal_voter : bool =  authorized_voter_pubkey.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu"; // not "super" voter
 
-	if (vote.hash.to_string().to_lowercase().find("x").unwrap_or(3) % 10 as usize) != (authorized_voter_pubkey.to_string().to_lowercase().find("x").unwrap_or(2) % 10 as usize) && authorized_voter_pubkey.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu"  {
-   		warn!(
-                    "Vote account has no authorized voter for slot.  Unable to vote"
-		);
-                return;
-		}
+    if in_group && normal_voter {
+        warn!(
+            "I ({}) will vote if I can!!!",*vote_account_pubkey
+);
+    } else {
+        warn!(
+            "Vote account has no authorized voter for slot.  Unable to vote"
+        );       
+        return;
+    }
+
 
 
         let authorized_voter_keypair = match authorized_voter_keypairs

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1229,9 +1229,7 @@ log::trace!("P: {}", authorized_voter_pubkey.to_string().find("T").unwrap_or(3))
     let group_gen = bank.epoch_stakes(bank.epoch()).unwrap().get_group_genr();
     let in_group = group_gen.in_group_for_seed(vote.slots[0],*vote_account_pubkey);
 
-    let normal_voter : bool =  authorized_voter_pubkey.to_string() != "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu"; // not "super" voter
-
-    if in_group && normal_voter {
+    if in_group {
         warn!(
             "I ({}) will vote if I can!!!",*vote_account_pubkey
 );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -849,23 +849,7 @@ mod tests {
         bank_client::BankClient,
         message_processor::{Executors, ThisInvokeContext},
     };
-    use solana_sdk::{
-        account::{create_account, Account},
-        account_utils::StateMut,
-        client::SyncClient,
-        clock::Clock,
-        feature_set::FeatureSet,
-        genesis_config::create_genesis_config,
-        instruction::Instruction,
-        instruction::{AccountMeta, InstructionError},
-        message::Message,
-        process_instruction::{BpfComputeBudget, MockInvokeContext},
-        pubkey::Pubkey,
-        rent::Rent,
-        signature::{Keypair, Signer},
-        system_program, sysvar,
-        transaction::TransactionError,
-    };
+    use solana_sdk::{account::{create_account, Account}, account_utils::StateMut, client::SyncClient, clock::Clock, feature_set::FeatureSet, genesis_config::create_genesis_config, instruction::Instruction, instruction::{AccountMeta, InstructionError}, message::Message, process_instruction::{BpfComputeBudget, MockInvokeContext}, pubkey::Pubkey, rent::Rent, signature::{Keypair, Signer}, system_program, sysvar, transaction::TransactionError, vote_group_gen::VoteGroupGenerator};
     use std::{cell::RefCell, fs::File, io::Read, ops::Range, rc::Rc, sync::Arc};
 
     struct TestInstructionMeter {
@@ -1091,6 +1075,8 @@ mod tests {
 
         // Case: limited budget
         let program_id = Pubkey::default();
+        let vgg =            VoteGroupGenerator::new_dummy();
+
         let mut invoke_context = ThisInvokeContext::new(
             &program_id,
             Rent::default(),
@@ -1115,6 +1101,7 @@ mod tests {
             Rc::new(RefCell::new(Executors::default())),
             None,
             Arc::new(FeatureSet::default()),
+    &vgg,
         );
         assert_eq!(
             Err(InstructionError::ProgramFailedToComplete),

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -321,6 +321,7 @@ pub fn process_instruction(
                 &from_keyed_account::<Clock>(next_keyed_account(keyed_accounts)?)?,
                 &vote,
                 &signers,
+                _invoke_context
             )
         }
         VoteInstruction::Withdraw(lamports) => {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -778,7 +778,6 @@ pub fn create_account(
 
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use crate::vote_state;
@@ -787,6 +786,8 @@ mod tests {
         account_utils::StateMut,
         hash::hash,
         keyed_account::{get_signers, next_keyed_account},
+        vote_group_gen::VoteGroupGenerator,
+        process_instruction::{MockInvokeContext},
     };
     use std::cell::RefCell;
 

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -32,6 +32,7 @@ pub mod program_stubs;
 pub mod pubkey;
 pub mod rent;
 pub mod sanitize;
+pub mod vote_group_gen;
 pub mod secp256k1_program;
 pub mod serialize_utils;
 pub mod short_vec;

--- a/sdk/program/src/vote_group_gen.rs
+++ b/sdk/program/src/vote_group_gen.rs
@@ -1,0 +1,153 @@
+//! This thing generates random voter groups of a given size
+//! Given the set of all authorized voters (their pubkeys) it selects one randomly
+//! then it picks a shift distance (some prime number less than the voter set size)
+//! and iteratively selects the rest of the group by shifting that distance
+//! its treating the set of voters as a ring 
+
+use crate::pubkey::{Pubkey};
+
+use std::collections::HashMap;
+use std::hash::Hasher;
+use std::collections::hash_map::DefaultHasher;
+//use std::sync::Arc;
+
+pub const OPTIMAL_VOTE_GROUP_SIZE : usize = 11;
+
+//#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
+//pub struct ArcPubkey(std::sync::Arc<Pubkey>);
+
+#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
+pub struct VoteGroupGenerator
+{
+    all_voters: Vec<Pubkey>,
+    all_distance: Vec<u32>,
+    group_size: usize,
+}
+
+impl VoteGroupGenerator
+{
+    pub fn new (map: &HashMap<Pubkey, Pubkey>, size: usize) -> VoteGroupGenerator {
+
+        let temp1: Vec<_> = map.into_iter().collect();
+       // let (temp, _): (Vec<Pubkey>, Vec<Pubkey>) = temp1.iter().cloned().unzip();
+       let mut temp = Vec::new();
+       for x in temp1{
+           let pubk = x.0;
+           let cloned :Pubkey= Pubkey::new_from_array(pubk.to_bytes());
+           temp.push(cloned);
+       }
+        let len = temp.len() as u32;
+        let mut initial = Vec::new();
+        initial.push(1);
+        for val in [2,3,5,7,11,13,17,23,29,31,37,41,43,47,51,53,57,59,61,67,71,73,79,83,87,89,97,101,103].iter() {
+           if (len > *val) && ((len % *val) != 0)   {
+               initial.push(*val);           
+           }
+        }
+        Self { all_voters : temp,
+            all_distance: initial.to_owned(),
+            group_size: size
+        } 
+    }
+
+    pub fn new_dummy () -> VoteGroupGenerator {
+        let hm: HashMap<Pubkey,Pubkey> = HashMap::new();
+        Self::new(&hm,1)
+    }
+
+    fn ring_shift(&self,a : usize,b: usize) -> usize{
+       let temp = a + b;
+        temp % self.all_voters.len()
+    }
+/* 
+    pub fn group_for_seed(&self,seed : u64) -> Vec<Pubkey>{
+        let mut hasher = DefaultHasher::new();
+        hasher.write_u64(seed); // seed the hash with the slot
+
+         let curhash = hasher.finish();
+         let mut ret = Vec::with_capacity(self.group_size);
+         let voters_len = self.all_voters.len();
+         let mut loc = (curhash % voters_len as u64) as usize;
+         ret.push(Pubkey::new(&self.all_voters[loc].to_bytes()));
+         if self.group_size > 1 {
+            let choose_dist = curhash % self.all_distance.len() as u64;
+            let dist = self.all_distance[choose_dist as usize] as usize;
+            for _ in 0..(self.group_size -1){
+                loc = self.ring_shift(loc,dist);
+                let temp = Pubkey::new(&self.all_voters[loc].to_bytes());
+                ret.push(temp);
+            }
+        }
+        println!("ret : {:?}", ret);
+         ret
+    }
+*/
+    pub fn in_group_for_seed(&self,seed : u64, test_key: Pubkey) -> bool {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_u64(seed); // seed the hash with the slot
+
+         let curhash = hasher.finish();
+         let voters_len = self.all_voters.len();
+         let mut loc = (curhash % voters_len as u64) as usize;
+         let temp = Pubkey::new(&self.all_voters[loc].to_bytes());
+         if test_key == temp{
+            return true;
+        }
+         if self.group_size > 1 {
+            let choose_dist = curhash % self.all_distance.len() as u64;
+            let dist = self.all_distance[choose_dist as usize] as usize;
+            for _ in 0..(self.group_size -1){
+                loc = self.ring_shift(loc,dist);
+                let temp = Pubkey::new(&self.all_voters[loc].to_bytes());
+                if test_key == temp{
+                    println!("found {:?}",test_key);
+                    return true;
+                }
+            }
+        }
+        false
+
+    }
+}
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vgg_multi() {
+        let canary = Pubkey::new_unique();
+        let mut hm: HashMap<Pubkey,Pubkey> = HashMap::new();
+        hm.insert(canary, Pubkey::new_unique());
+
+        for it in 0..4{
+            let val = Pubkey::new_unique();
+            hm.insert(val, Pubkey::new_unique());
+            println!("insert {}",it);
+        }
+        let vgg = VoteGroupGenerator::new(&hm,hm.len());
+        for h in hm.keys() {
+            let found = vgg.in_group_for_seed(0, *h);
+            assert!(found);
+        }
+
+        let not_canary = Pubkey::new_unique();
+        assert_eq!(vgg.in_group_for_seed(0, not_canary),false);
+    }
+
+    #[test]
+
+    fn test_vgg_single() {
+        let canary = Pubkey::new_unique();
+        let mut hm: HashMap<Pubkey,Pubkey> = HashMap::new();
+        hm.insert(canary, Pubkey::new_unique());
+
+        let vgg = VoteGroupGenerator::new(&hm,hm.len());
+        for h in hm.keys() {
+            let found = vgg.in_group_for_seed(0, *h);
+            assert!(found);
+        }
+
+        let not_canary = Pubkey::new_unique();
+        assert_eq!(vgg.in_group_for_seed(0, not_canary),false);
+    }
+
+}

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -64,8 +64,9 @@ pub trait InvokeContext {
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
     /// Get an account from a pre-account
     fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<Account>>;
-}
 
+    fn voter_in_group(&self, seed: u64,key: Pubkey) -> bool;
+}
 /// Convenience macro to log a message with an `Rc<RefCell<dyn Logger>>`
 #[macro_export]
 macro_rules! ic_logger_msg {
@@ -370,5 +371,8 @@ impl InvokeContext for MockInvokeContext {
     }
     fn get_account(&self, _pubkey: &Pubkey) -> Option<RefCell<Account>> {
         None
+    }
+    fn voter_in_group(&self, _: u64,_: Pubkey) -> bool {
+        true
     }
 }


### PR DESCRIPTION
#### Problem
Speed up & lighten up the validators by choosing a minimum set of voters, eleven (11), for a given slot.  
#### Summary of Changes
During replay_stage in push_vote the validator calls a method to that determines if it is part of a subset of voters for the slot.
The vote instruction is changed correspondingly to verify that the voter for the instruction (based on the slot)

The vote groups are found by choosing randomly from all the authorized voters.  There is a new file, vote_group_gen.rs implementing VoteGroupGenerator, that handles the group selection.  VoteGroupGenerator lives inside the EpochStakes structure (inside the Bank) since it depends on accessing all the authorized (staked) voters.

Makes validation more scalable/consistent by not randomly selecting the voters *in isolation* which results in a bell curve distribution of group sizes (e.g. it will *average* 10% of voters selected but can select **very occasionally** zero voters). Because this method takes advantage of tracking all the voters it can choose all eleven of the voters in the group in one function.  Also since it is not isolated it keeps the group size consistent against a (hopefully) growing number of voters. (vs the previous code which will choose a percent of the voters such that the number of voters voting grows with the number of potential voters.

#### Issues
The change needs to be well tested (like much better than currently - in an actual cluster and passing through an epoch & genesis processes) since it is a breaking change (all validators would need to be migrated in one go). 
