### PR TITLE
replace sad (non-standard) hash with new happy (standard) hash

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1472,8 +1472,11 @@ impl ReplayStage {
         log::trace!("authorized_voter_pubkey.replay_stage {}", authorized_voter_pubkey);
         log::trace!("authorized_voter_pubkey_string.replay_stage {}", authorized_voter_pubkey.to_string());
         log::trace!("vote_hash.replay_stage: {}", vote.hash);
-	log::trace!("vote_slots.replay_stage: {}", vote.slots[0]);
+	    log::trace!("vote_slots.replay_stage: {}", vote.slots[0]);
+        let mut check_allowed = Measure::start("check allowed vote");
+
         let vote_ok = bank.vote_allowed(vote.slots[0],vote.hash,authorized_voter_pubkey);
+        check_allowed.stop();
         if vote_ok  {
             warn!(
                 "I ({}) will vote if I can!!!",authorized_voter_pubkey.to_string()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1479,13 +1479,15 @@ impl ReplayStage {
         check_allowed.stop();
         if vote_ok  {
             warn!(
-                "I ({}) will vote if I can!!!",authorized_voter_pubkey.to_string()
+                "({} ms) I ({}) will vote if I can!!! ",check_allowed.as_ms(), authorized_voter_pubkey.to_string()
             );
         } else {
             warn!(
-                "Vote account {} not selected voter for slot {}.  Better luck next time",
-		  authorized_voter_pubkey.to_string(),
+                "({} ms) Vote account {} not selected voter for slot {}.  Better luck next time",
+                check_allowed.as_ms(),
+                  authorized_voter_pubkey.to_string(),
                     vote.slots[0]
+      
             );
             return None;
         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1479,15 +1479,13 @@ impl ReplayStage {
         check_allowed.stop();
         if vote_ok  {
             warn!(
-                "({} ms) I ({}) will vote if I can!!! ",check_allowed.as_ms(), authorized_voter_pubkey.to_string()
+                "I ({}) will vote if I can!!!",authorized_voter_pubkey.to_string()
             );
         } else {
             warn!(
-                "({} ms) Vote account {} not selected voter for slot {}.  Better luck next time",
-                check_allowed.as_ms(),
-                  authorized_voter_pubkey.to_string(),
+                "Vote account {} not selected voter for slot {}.  Better luck next time",
+		  authorized_voter_pubkey.to_string(),
                     vote.slots[0]
-      
             );
             return None;
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5938,15 +5938,11 @@ impl Bank {
         let random_vote_hash = rand_voter_hash(hash, voter);
         let random_voter_val = random_vote_hash.to_u128();
         let random_will_vote = (random_voter_val % 10) == 0;
-        log::trace!(
-            "H_vote: {}",
-            ((hash.to_string().chars().nth(0).unwrap() as usize) % 10)
-        );
         let always_voter = voter.to_string() == SAFECOIN_ALWAYS_VOTER;
         
         let will_vote = random_will_vote || always_voter;
         rand_elapsed.stop();
-        log::trace!("rando hash: {} voter {} will vote: {} s {}", hash,voter, will_vote,rand_elapsed.as_us());
+        log::trace!("rando hash: {} voter {} will vote: {} ms {}", hash,voter, will_vote,rand_elapsed.as_ms());
         return will_vote
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5938,11 +5938,15 @@ impl Bank {
         let random_vote_hash = rand_voter_hash(hash, voter);
         let random_voter_val = random_vote_hash.to_u128();
         let random_will_vote = (random_voter_val % 10) == 0;
+        log::trace!(
+            "H_vote: {}",
+            ((hash.to_string().chars().nth(0).unwrap() as usize) % 10)
+        );
         let always_voter = voter.to_string() == SAFECOIN_ALWAYS_VOTER;
         
         let will_vote = random_will_vote || always_voter;
         rand_elapsed.stop();
-        log::trace!("rando hash: {} voter {} will vote: {} ms {}", hash,voter, will_vote,rand_elapsed.as_ms());
+        log::trace!("rando hash: {} voter {} will vote: {} s {}", hash,voter, will_vote,rand_elapsed.as_us());
         return will_vote
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5934,7 +5934,7 @@ impl Bank {
     // supports VoteModerator trait 
     // has a 10% chance of allowing a vote 
     fn is_rando_voter(&self, hash: Hash, voter: Pubkey) -> bool {
- 
+        let mut rand_elapsed = Measure::start("rando time");
         let random_vote_hash = rand_voter_hash(hash, voter);
         let random_voter_val = random_vote_hash.to_u128();
         let random_will_vote = (random_voter_val % 10) == 0;
@@ -5945,8 +5945,8 @@ impl Bank {
         let always_voter = voter.to_string() == SAFECOIN_ALWAYS_VOTER;
         
         let will_vote = random_will_vote || always_voter;
-        log::trace!("rando hash: {} voter {} will vote: {}", hash,voter, will_vote);
-
+        rand_elapsed.stop();
+        log::trace!("rando hash: {} voter {} will vote: {} s {}", hash,voter, will_vote,rand_elapsed.as_us());
         return will_vote
     }
 

--- a/runtime/src/vote_group_gen.rs
+++ b/runtime/src/vote_group_gen.rs
@@ -7,15 +7,18 @@
 use safecoin_sdk::{
     pubkey::Pubkey,
     hash::Hash,
+    hash::extend_and_hash,
 };
+
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::str::FromStr;
 
 pub static SAFECOIN_ALWAYS_VOTER: &str = "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu";
 
-//#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
-//pub struct ArcPubkey(std::sync::Arc<Pubkey>);
+pub fn rand_voter_hash( hash: Hash, test_key: Pubkey) -> Hash{
+    extend_and_hash(&hash,  &test_key.to_bytes())
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct VoteGroupGenerator {

--- a/runtime/src/vote_group_gen.rs
+++ b/runtime/src/vote_group_gen.rs
@@ -130,7 +130,7 @@ impl VoteGroupGenerator {
             }
         }
         
-        log::trace!("in_group = {} us = {}", result, ingrp_elapsed.as_us());
+        log::trace!("in_group = {} ms = {}", result, ingrp_elapsed.as_ms());
         result
     }
 }

--- a/runtime/src/vote_group_gen.rs
+++ b/runtime/src/vote_group_gen.rs
@@ -7,15 +7,18 @@
 use safecoin_sdk::{
     pubkey::Pubkey,
     hash::Hash,
+    hash::extend_and_hash,
 };
+
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::str::FromStr;
 
 pub static SAFECOIN_ALWAYS_VOTER: &str = "83E5RMejo6d98FV1EAXTx5t4bvoDMoxE4DboDee3VJsu";
 
-//#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
-//pub struct ArcPubkey(std::sync::Arc<Pubkey>);
+pub fn rand_voter_hash( hash: Hash, test_key: Pubkey) -> Hash{
+    safecoin_sdk::hash::extend_and_hash(&hash,  &test_key.to_bytes())
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct VoteGroupGenerator {

--- a/runtime/src/vote_group_gen.rs
+++ b/runtime/src/vote_group_gen.rs
@@ -130,7 +130,7 @@ impl VoteGroupGenerator {
             }
         }
         
-        log::trace!("in_group = {} ms = {}", result, ingrp_elapsed.as_ms());
+        log::trace!("in_group = {} us = {}", result, ingrp_elapsed.as_us());
         result
     }
 }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -5,6 +5,7 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use sha2::{Digest, Sha256};
 use std::{convert::TryFrom, fmt, mem, str::FromStr};
 use thiserror::Error;
+use std::convert::TryInto;
 
 pub const HASH_BYTES: usize = 32;
 /// Maximum string length of a base58 encoded hash
@@ -26,7 +27,7 @@ const MAX_BASE58_LEN: usize = 44;
     AbiExample,
 )]
 #[repr(transparent)]
-pub struct Hash(pub [u8; HASH_BYTES]);
+pub struct Hash(pub [u8; 32]);
 
 #[derive(Clone, Default)]
 pub struct Hasher {
@@ -95,6 +96,10 @@ impl FromStr for Hash {
     }
 }
 
+fn pop128(hunk: &[u8]) -> &[u8; 16] {
+    hunk.try_into().expect("slice with incorrect length")
+}
+
 impl Hash {
     pub fn new(hash_slice: &[u8]) -> Self {
         Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
@@ -117,6 +122,14 @@ impl Hash {
 
     pub fn to_bytes(self) -> [u8; HASH_BYTES] {
         self.0
+    }
+
+    pub fn to_u128(self) -> u128 {
+        let one_slice = pop128(&self.0[0..15]);
+        let one = u128::from_le_bytes(*one_slice);
+        let two_slice = pop128(&self.0[16..31]);
+        let two = u128::from_le_bytes(*two_slice);
+        one ^ two
     }
 }
 


### PR DESCRIPTION
#### Problem
It appears that is_rando_voter (in bank.rs)  favors certain pub key values leading to unfair voting.  This is completely plausible because the function does, in fact use the authorized voter pub key as a string (*after* converting to bs58).  It is gobblety-gook code that is difficult to read (and apparently not a fair hash algorithm.)

#### Summary of Changes
replace that sad code using standard solana_sdk::hash::Hash.  
1. We use Hash.extend_and_hash to add the pub key to the vote hash.  
2. This gets us a 256 bit hash
3.  Convert that to a 128 bit value (so we can do math)
4. take the value and modulo by 10 
5. if that result is zero (should be 1/10th of the values) then return true.

Fixes #
